### PR TITLE
Update midnightlib_version to 1.9.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ maven_group=com.loohp
 archives_base_name=ImageFrameClient
 
 # Library Versions
-midnightlib_version=1.8.3+1.21.9-fabric
+midnightlib_version=1.9.2+1.21.11-fabric
 modmenu_version=17.0.0-alpha.1


### PR DESCRIPTION
Change midnightlib version to 1.9.2 because 1.8.3 doesn't support 1.21.11 and crashes on singleplayer worlds.